### PR TITLE
Fix - Failed to build cryptography

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ EXPOSE 3030
 
 WORKDIR /opt/elastalert
 
-RUN pip3 install --no-cache-dir cryptography --user
+RUN pip3 install --no-cache-dir cryptography=="2.8" --user
 RUN pip3 install --no-cache-dir -r requirements.txt --user
 
 WORKDIR /opt/elastalert-server


### PR DESCRIPTION
- Set cryptography version 2.8 to fix "ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly"